### PR TITLE
fix NP 283 initial data for use input hook sets correctly when source isnt published

### DIFF
--- a/src/plugins/strapi-plugin-internal-links/admin/src/components/input/use-internal-link-input.ts
+++ b/src/plugins/strapi-plugin-internal-links/admin/src/components/input/use-internal-link-input.ts
@@ -36,7 +36,6 @@ export const isInternalLink = (object: any): object is IInternalLink => {
 	return (
 		'id' in object &&
 		'sourceContentTypeUid' in object &&
-		'sourceContentTypeId' in object &&
 		'sourceFieldName' in object &&
 		'url' in object &&
 		'text' in object &&
@@ -63,7 +62,7 @@ const useInternalLinkInput = (
 
 		if (!isInternalLink(data)) return newInternalLink;
 
-		if (data.sourceContentTypeUid && data.sourceContentTypeId && data.sourceFieldName) {
+		if (data.sourceContentTypeUid && data.sourceFieldName) {
 			return data;
 		}
 

--- a/src/plugins/strapi-plugin-internal-links/package.json
+++ b/src/plugins/strapi-plugin-internal-links/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@webbio/strapi-plugin-internal-links",
-	"version": "1.4.7",
+	"version": "1.4.8",
 	"description": "A custom field for Strapi that can create internal links",
 	"scripts": {
 		"develop": "tsc -p tsconfig.server.json -w",


### PR DESCRIPTION


fix(use-internal-link-input): remove unnecessary check for sourceContentTypeId in useInternalLinkInput function
chore(package.json): bump version to 1.4.8